### PR TITLE
Fix PRT typo

### DIFF
--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -199,7 +199,7 @@ export function PackedRadialTreeDemo() {
               hierarchical datasets as elegantly arranged circular nodes in a
               radial layout. Leaves at each level are packed around their
               parents. Branches are balanced around the radial space. Finally,
-              collisons are resolved to provide a overall packed look to this
+              collisions are resolved to provide an overall packed look to this
               visualization.
             </Text>
           </Box>


### PR DESCRIPTION
## Summary
- fix typos in the Packed Radial Tree demo description

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684455677c2883218565c429177393f3