### PR TITLE
Fix React version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for my personal website and blog, hoste
 ## Built With
 
 - Vite (https://vitejs.dev/)
-- React 19 + TypeScript
+- React 18 + TypeScript
 - Chakra UI (https://chakra-ui.com/)
 - MDX for writing blog posts
 - D3 & visx for data visualizations


### PR DESCRIPTION
## Summary
- correct README bullet to mention React 18

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844557e0a5c832188fbae6b7e450bb4