### PR TITLE
Improve theme with beige-brown colors

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,10 +2,11 @@ import { Box, Flex } from "@chakra-ui/react";
 import { Link, useLocation } from "react-router-dom";
 import { ColorModeButton } from "./ui/color-mode-button";
 import { useColorModeValue } from "./ui/color-mode";
+import { accent } from "../theme";
 
 export const Navbar = () => {
   const location = useLocation();
-  const activeLinkColor = useColorModeValue("#6e5d44", "#DFD0B8");
+  const activeLinkColor = useColorModeValue(accent.light, accent.dark);
   const inactiveLinkColor = useColorModeValue("gray.600", "gray.400");
 
   const getLinkStyle = (path: string) => ({

--- a/src/components/ui/provider.tsx
+++ b/src/components/ui/provider.tsx
@@ -4,17 +4,12 @@ import {
   ChakraProvider,
   createSystem,
   defaultConfig,
-  defineConfig,
 } from "@chakra-ui/react";
 import { ColorModeProvider } from "./color-mode-provider";
 import type { ColorModeProviderProps } from "./color-mode";
-import { textStyles } from "./textStyles";
+import { theme } from "../../theme";
 
-const config = defineConfig({
-  theme: { textStyles },
-});
-
-const system = createSystem(defaultConfig, config);
+const system = createSystem(defaultConfig, theme);
 
 export function Provider(props: ColorModeProviderProps) {
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { accent } from "../theme";
 import featuredData from "../data/featured.json";
 
 // Define types for the post data
@@ -38,7 +39,7 @@ interface Post {
 }
 
 export const Home = () => {
-  const highlightColor = useColorModeValue("#6e5d44", "#DFD0B8");
+  const highlightColor = useColorModeValue(accent.light, accent.dark);
   const featuredPosts = (featuredData as Post[]).filter(
     (post) => post.featured
   );

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -12,6 +12,7 @@ import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import postsData from "../data/posts.json";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { accent } from "../theme";
 
 interface Post {
   title: string;
@@ -23,8 +24,9 @@ interface Post {
 
 export const Posts = () => {
   const { posts } = postsData as { posts: Post[] };
-  const highlightColor = useColorModeValue("#6e5d44", "#DFD0B8");
-
+  const highlightColor = useColorModeValue(accent.light, accent.dark);
+  const buttonTextColor = useColorModeValue("white", "gray.800");
+  
   // Helper function to determine if a link is internal or external
   const isInternalLink = (url: string): boolean => {
     return (
@@ -55,7 +57,12 @@ export const Posts = () => {
               <HStack mt={2} gap={4}>
                 {isInternalLink(post.link) ? (
                   <RouterLink to={post.link}>
-                    <Button size="sm" variant="outline">
+                    <Button
+                      size="sm"
+                      bg={highlightColor}
+                      color={buttonTextColor}
+                      _hover={{ bg: highlightColor }}
+                    >
                       Read More
                     </Button>
                   </RouterLink>
@@ -65,7 +72,12 @@ export const Posts = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <Button size="sm" variant="outline">
+                    <Button
+                      size="sm"
+                      bg={highlightColor}
+                      color={buttonTextColor}
+                      _hover={{ bg: highlightColor }}
+                    >
                       Read More
                     </Button>
                   </ChakraLink>
@@ -76,7 +88,12 @@ export const Posts = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <Button size="sm" variant="outline">
+                    <Button
+                      size="sm"
+                      bg={highlightColor}
+                      color={buttonTextColor}
+                      _hover={{ bg: highlightColor }}
+                    >
                       Watch Video
                     </Button>
                   </ChakraLink>

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -13,13 +13,14 @@ import {
 import { FormEvent, useState } from "react";
 import { Page } from "../components/Page";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { accent } from "../theme";
 import publicationsData from "../data/publications.json";
 
 export const Publications = () => {
   const [selectedType, setSelectedType] = useState<string>("all");
   const [selectedYear, setSelectedYear] = useState<string>("all");
 
-  const highlightColor = useColorModeValue("#6e5d44", "#DFD0B8");
+  const highlightColor = useColorModeValue(accent.light, accent.dark);
 
   // Get unique types and years for filters
   const types = [

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@chakra-ui/react";
+import { textStyles } from "./components/ui/textStyles";
+
+export const accent = {
+  light: "#6e5d44",
+  dark: "#DFD0B8",
+};
+
+export const theme = defineConfig({
+  theme: {
+    textStyles,
+    semanticTokens: {
+      colors: {
+        accent: {
+          value: { _light: accent.light, _dark: accent.dark },
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add central beige/brown accent color tokens
- use accent in Navbar and pages
- color Posts page buttons with accent

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d605b7f4832196bf2407a1a54d01