### PR TITLE
Create reusable two-panel layout

### DIFF
--- a/src/components/TwoPanelWithScroll.tsx
+++ b/src/components/TwoPanelWithScroll.tsx
@@ -1,0 +1,38 @@
+import { Box, Grid } from "@chakra-ui/react";
+import { ReactNode } from "react";
+
+interface TwoPanelWithScrollProps {
+  left: ReactNode;
+  right: ReactNode;
+}
+
+/**
+ * Layout with a sticky left panel and scrollable right panel on larger screens.
+ * On small screens both panels scroll naturally.
+ */
+export const TwoPanelWithScroll = ({ left, right }: TwoPanelWithScrollProps) => {
+  return (
+    <Grid
+      templateColumns={{ base: "1fr", md: "300px 1fr" }}
+      gap={{ base: 8, md: "100px" }}
+      minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
+      mx="auto"
+      w="fit-content"
+    >
+      <Box
+        position={{ base: "static", md: "sticky" }}
+        top={{ base: "auto", md: 0 }}
+        height={{ base: "auto", md: "fit-content" }}
+        alignSelf={{ base: "stretch", md: "start" }}
+      >
+        {left}
+      </Box>
+      <Box
+        overflowY="auto"
+        maxH={{ base: "auto", md: "calc(100vh - 100px)" }}
+      >
+        {right}
+      </Box>
+    </Grid>
+  );
+};

--- a/src/components/TwoPanelWithScroll.tsx
+++ b/src/components/TwoPanelWithScroll.tsx
@@ -1,38 +1,48 @@
 import { Box, Grid } from "@chakra-ui/react";
-import { ReactNode } from "react";
-
-interface TwoPanelWithScrollProps {
-  left: ReactNode;
-  right: ReactNode;
-}
+import { ReactNode, FC } from "react";
 
 /**
- * Layout with a sticky left panel and scrollable right panel on larger screens.
- * On small screens both panels scroll naturally.
+ * Compound layout component with a sticky left panel and scrollable right panel
+ * on larger screens. On small screens both panels scroll naturally.
  */
-export const TwoPanelWithScroll = ({ left, right }: TwoPanelWithScrollProps) => {
+interface PanelProps {
+  children: ReactNode;
+}
+
+interface TwoPanelWithScrollCompound extends FC<PanelProps> {
+  LeftPanel: FC<PanelProps>;
+  RightPanel: FC<PanelProps>;
+}
+
+export const TwoPanelWithScroll: TwoPanelWithScrollCompound = ({ children }) => (
+  <Grid
+    templateColumns={{ base: "1fr", md: "300px 1fr" }}
+    gap={{ base: 8, md: "100px" }}
+    minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
+    mx="auto"
+    w="fit-content"
+  >
+    {children}
+  </Grid>
+);
+
+TwoPanelWithScroll.LeftPanel = function LeftPanel({ children }: PanelProps) {
   return (
-    <Grid
-      templateColumns={{ base: "1fr", md: "300px 1fr" }}
-      gap={{ base: 8, md: "100px" }}
-      minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
-      mx="auto"
-      w="fit-content"
+    <Box
+      position={{ base: "static", md: "sticky" }}
+      top={{ base: "auto", md: 0 }}
+      height={{ base: "auto", md: "fit-content" }}
+      alignSelf={{ base: "stretch", md: "start" }}
     >
-      <Box
-        position={{ base: "static", md: "sticky" }}
-        top={{ base: "auto", md: 0 }}
-        height={{ base: "auto", md: "fit-content" }}
-        alignSelf={{ base: "stretch", md: "start" }}
-      >
-        {left}
-      </Box>
-      <Box
-        overflowY="auto"
-        maxH={{ base: "auto", md: "calc(100vh - 100px)" }}
-      >
-        {right}
-      </Box>
-    </Grid>
+      {children}
+    </Box>
+  );
+};
+
+TwoPanelWithScroll.RightPanel = function RightPanel({ children }: PanelProps) {
+  return (
+    <Box overflowY="auto" maxH={{ base: "auto", md: "calc(100vh - 100px)" }}>
+      {children}
+    </Box>
   );
 };

--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -169,8 +169,8 @@ export function PackedRadialTreeDemo() {
 
   return (
     <Page>
-      <TwoPanelWithScroll
-        left={
+      <TwoPanelWithScroll>
+        <TwoPanelWithScroll.LeftPanel>
           <Box h="75vh">
             {uatData && (
               <PackedRadialTree
@@ -180,8 +180,8 @@ export function PackedRadialTreeDemo() {
               />
             )}
           </Box>
-        }
-        right={
+        </TwoPanelWithScroll.LeftPanel>
+        <TwoPanelWithScroll.RightPanel>
           <Box maxW="72ch" mx="auto" maxH="calc(100vh - 120px)" overflow="auto" px={8}>
             <Stack gap={10}>
             {/* Header */}
@@ -347,8 +347,8 @@ export function PackedRadialTreeDemo() {
             </Box>
           </Stack>
           </Box>
-          }
-        />
+        </TwoPanelWithScroll.RightPanel>
+      </TwoPanelWithScroll>
       </Page>
     );
 }

--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -1,7 +1,6 @@
 import {
   Badge,
   Box,
-  Grid,
   Heading,
   HStack,
   Stack,
@@ -17,6 +16,7 @@ import {
 import { useEffect, useState } from "react";
 import { useColorMode } from "../../components/ui/color-mode";
 import { Page } from "../../components/Page";
+import { TwoPanelWithScroll } from "../../components/TwoPanelWithScroll";
 
 const parseUATData = async (): Promise<TreeNode> => {
   try {
@@ -169,32 +169,21 @@ export function PackedRadialTreeDemo() {
 
   return (
     <Page>
-      {/* TODO: Fix the height hardcoding - inconsistent height values between Grid maxH and Box h */}
-      <Grid
-        templateColumns={{ base: "1fr", lg: "3fr 2fr" }}
-        overflowY="auto"
-        px={7}
-      >
-        {/* Left Column - Visualization (Full Height) */}
-        <Box h="75vh">
-          {uatData && (
-            <PackedRadialTree
-              data={uatData}
-              onNodeSelect={handleNodeSelect}
-              options={config}
-            />
-          )}
-        </Box>
-
-        {/* Right Column - Content */}
-        <Box
-          maxW="72ch"
-          mx="auto"
-          maxH="calc(100vh - 120px)"
-          overflow="auto"
-          px={8}
-        >
-          <Stack gap={10}>
+      <TwoPanelWithScroll
+        left={
+          <Box h="75vh">
+            {uatData && (
+              <PackedRadialTree
+                data={uatData}
+                onNodeSelect={handleNodeSelect}
+                options={config}
+              />
+            )}
+          </Box>
+        }
+        right={
+          <Box maxW="72ch" mx="auto" maxH="calc(100vh - 120px)" overflow="auto" px={8}>
+            <Stack gap={10}>
             {/* Header */}
             <Box>
               <Heading as="h1" size="2xl">
@@ -357,8 +346,9 @@ export function PackedRadialTreeDemo() {
               </VStack>
             </Box>
           </Stack>
-        </Box>
-      </Grid>
-    </Page>
-  );
+          </Box>
+          }
+        />
+      </Page>
+    );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,8 @@
 import {
   Box,
+  Grid,
   Link as ChakraLink,
   Container,
-  Grid,
   Heading,
   HStack,
   Image,
@@ -13,6 +13,7 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { TwoPanelWithScroll } from "../components/TwoPanelWithScroll";
 import featuredData from "../data/featured.json";
 
 // Define types for the post data
@@ -47,115 +48,113 @@ export const Home = () => {
   return (
     <Page>
       <Container maxW="container.xl" px={8}>
-        <Grid
-          templateColumns={{ base: "1fr", md: "300px 1fr" }}
-          gap="100px"
-          minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
-          mx="auto"
-          w="fit-content"
-        >
-          <Stack
-            gap={6}
-            position={{ base: "static", md: "sticky" }}
-            top={{ base: "auto", md: "0" }}
-            height={{ base: "auto", md: "fit-content" }}
-            alignSelf={{ base: "stretch", md: "start" }}
-          >
-            <Stack position="relative" mt={10}>
-              <Image
-                src="/profile.jpg"
-                alt="Karthik Badam"
-                borderRadius="full"
-                width="100%"
-                maxWidth="150px"
-                height="auto"
-                objectFit="cover"
-                boxShadow="2xl"
-                transition="transform 0.3s"
-                _hover={{ transform: "scale(1.05)" }}
-              />
-            </Stack>
-            <Stack gap={4}>
-              <Heading
-                fontWeight="semibold"
-                size="2xl"
-                css={{
-                  background: highlightColor,
-                  WebkitBackgroundClip: "text",
-                  WebkitTextFillColor: "transparent",
-                }}
-              >
-                Karthik Badam
-              </Heading>
-              <HStack gap={2} wrap="wrap">
-                <Tag.Root>
-                  <Tag.Label>Full-Stack Engineer</Tag.Label>
-                </Tag.Root>
-                <Tag.Root>
-                  <Tag.Label>Apple</Tag.Label>
-                </Tag.Root>
-                <Tag.Root>
-                  <Tag.Label>Machine Learning</Tag.Label>
-                </Tag.Root>
-              </HStack>
-              <Text fontSize="md" color="gray.fg" lineHeight="tall">
-                Creating tools to explore, explain, and augment datasets that
-                feed into large language and vision models.
-              </Text>
-            </Stack>
-          </Stack>
-          <Stack py={2}>
-            <Stack gap={4} maxW={{ base: "100%", lg: "80ch" }}>
-              <Heading size="xl">Featured Works</Heading>
-              {/* Featured Posts as Large Cards - Side by Side */}
-              {featuredPosts.length > 0 && (
-                <Grid
-                  templateColumns={{
-                    base: "1fr",
-                    md: featuredPosts.length === 1 ? "1fr" : "1fr 1fr",
+        <TwoPanelWithScroll
+          left={
+            <Stack
+              gap={6}
+              position={{ base: "static", md: "sticky" }}
+              top={{ base: "auto", md: "0" }}
+              height={{ base: "auto", md: "fit-content" }}
+              alignSelf={{ base: "stretch", md: "start" }}
+            >
+              <Stack position="relative" mt={10}>
+                <Image
+                  src="/profile.jpg"
+                  alt="Karthik Badam"
+                  borderRadius="full"
+                  width="100%"
+                  maxWidth="150px"
+                  height="auto"
+                  objectFit="cover"
+                  boxShadow="2xl"
+                  transition="transform 0.3s"
+                  _hover={{ transform: "scale(1.05)" }}
+                />
+              </Stack>
+              <Stack gap={4}>
+                <Heading
+                  fontWeight="semibold"
+                  size="2xl"
+                  css={{
+                    background: highlightColor,
+                    WebkitBackgroundClip: "text",
+                    WebkitTextFillColor: "transparent",
                   }}
-                  gap={6}
                 >
-                  {featuredPosts.map((post, index) => (
-                    <FeaturedPostCard key={index} post={post} />
-                  ))}
-                </Grid>
-              )}
+                  Karthik Badam
+                </Heading>
+                <HStack gap={2} wrap="wrap">
+                  <Tag.Root>
+                    <Tag.Label>Full-Stack Engineer</Tag.Label>
+                  </Tag.Root>
+                  <Tag.Root>
+                    <Tag.Label>Apple</Tag.Label>
+                  </Tag.Root>
+                  <Tag.Root>
+                    <Tag.Label>Machine Learning</Tag.Label>
+                  </Tag.Root>
+                </HStack>
+                <Text fontSize="md" color="gray.fg" lineHeight="tall">
+                  Creating tools to explore, explain, and augment datasets that
+                  feed into large language and vision models.
+                </Text>
+              </Stack>
+            </Stack>
+          }
+          right={
+            <Stack py={2}>
+              <Stack gap={4} maxW={{ base: "100%", lg: "80ch" }}>
+                <Heading size="xl">Featured Works</Heading>
+                {/* Featured Posts as Large Cards - Side by Side */}
+                {featuredPosts.length > 0 && (
+                  <Grid
+                    templateColumns={{
+                      base: "1fr",
+                      md: featuredPosts.length === 1 ? "1fr" : "1fr 1fr",
+                    }}
+                    gap={6}
+                  >
+                    {featuredPosts.map((post, index) => (
+                      <FeaturedPostCard key={index} post={post} />
+                    ))}
+                  </Grid>
+                )}
 
-              {/* Grid for Smaller Cards */}
-              {restPosts.length > 0 && (
-                <Grid
-                  templateColumns={{
-                    base: "1fr",
-                    md: "1fr 1fr",
-                  }}
-                  gap={6}
-                >
-                  {restPosts.map((post, index) => (
-                    <Box key={index}>
-                      {post.link.startsWith("http") ? (
-                        <ChakraLink
-                          href={post.link}
-                          _hover={{ textDecoration: "none" }}
-                          h="100%"
-                        >
-                          <PostCard post={post} />
-                        </ChakraLink>
-                      ) : (
-                        <RouterLink
-                          to={post.link}
-                          style={{ textDecoration: "none" }}
-                        >
-                          <PostCard post={post} />
-                        </RouterLink>
-                      )}
-                    </Box>
-                  ))}
-                </Grid>
-              )}
+                {/* Grid for Smaller Cards */}
+                {restPosts.length > 0 && (
+                  <Grid
+                    templateColumns={{
+                      base: "1fr",
+                      md: "1fr 1fr",
+                    }}
+                    gap={6}
+                  >
+                    {restPosts.map((post, index) => (
+                      <Box key={index}>
+                        {post.link.startsWith("http") ? (
+                          <ChakraLink
+                            href={post.link}
+                            _hover={{ textDecoration: "none" }}
+                            h="100%"
+                          >
+                            <PostCard post={post} />
+                          </ChakraLink>
+                        ) : (
+                          <RouterLink
+                            to={post.link}
+                            style={{ textDecoration: "none" }}
+                          >
+                            <PostCard post={post} />
+                          </RouterLink>
+                        )}
+                      </Box>
+                    ))}
+                  </Grid>
+                )}
+              </Stack>
             </Stack>
-          </Stack>
-        </Grid>
+          }
+        />
       </Container>
     </Page>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,15 +48,9 @@ export const Home = () => {
   return (
     <Page>
       <Container maxW="container.xl" px={8}>
-        <TwoPanelWithScroll
-          left={
-            <Stack
-              gap={6}
-              position={{ base: "static", md: "sticky" }}
-              top={{ base: "auto", md: "0" }}
-              height={{ base: "auto", md: "fit-content" }}
-              alignSelf={{ base: "stretch", md: "start" }}
-            >
+        <TwoPanelWithScroll>
+          <TwoPanelWithScroll.LeftPanel>
+            <Stack gap={6}>
               <Stack position="relative" mt={10}>
                 <Image
                   src="/profile.jpg"
@@ -100,8 +94,8 @@ export const Home = () => {
                 </Text>
               </Stack>
             </Stack>
-          }
-          right={
+          </TwoPanelWithScroll.LeftPanel>
+          <TwoPanelWithScroll.RightPanel>
             <Stack py={2}>
               <Stack gap={4} maxW={{ base: "100%", lg: "80ch" }}>
                 <Heading size="xl">Featured Works</Heading>
@@ -153,8 +147,8 @@ export const Home = () => {
                 )}
               </Stack>
             </Stack>
-          }
-        />
+          </TwoPanelWithScroll.RightPanel>
+        </TwoPanelWithScroll>
       </Container>
     </Page>
   );


### PR DESCRIPTION
## Summary
- add `TwoPanelWithScroll` layout component
- use the new layout in `Home` page
- apply the layout to `PackedRadialTreeDemo`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d045c3248321954fa997d12b8530