### PR TITLE
Improve theme with beige-brown colors

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,10 +2,11 @@ import { Box, Flex } from "@chakra-ui/react";
 import { Link, useLocation } from "react-router-dom";
 import { ColorModeButton } from "./ui/color-mode-button";
 import { useColorModeValue } from "./ui/color-mode";
+import { accent } from "../theme";
 
 export const Navbar = () => {
   const location = useLocation();
-  const activeLinkColor = useColorModeValue("#6e5d44", "#DFD0B8");
+  const activeLinkColor = useColorModeValue(accent.light, accent.dark);
   const inactiveLinkColor = useColorModeValue("gray.600", "gray.400");
 
   const getLinkStyle = (path: string) => ({

--- a/src/components/ui/provider.tsx
+++ b/src/components/ui/provider.tsx
@@ -4,17 +4,12 @@ import {
   ChakraProvider,
   createSystem,
   defaultConfig,
-  defineConfig,
 } from "@chakra-ui/react";
 import { ColorModeProvider } from "./color-mode-provider";
 import type { ColorModeProviderProps } from "./color-mode";
-import { textStyles } from "./textStyles";
+import { theme } from "../../theme";
 
-const config = defineConfig({
-  theme: { textStyles },
-});
-
-const system = createSystem(defaultConfig, config);
+const system = createSystem(defaultConfig, theme);
 
 export function Provider(props: ColorModeProviderProps) {
   return (

--- a/src/data/featured.json
+++ b/src/data/featured.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Exploring Complex Hierarchies",
+    "title": "Explore Complex Hierarchies using a Packed Radial Tree",
     "abstract": "An interactive visualization that renders hierarchical datasets as elegantly-arranged circular nodes in a radial layout. Explore the Unified Astronomy Thesaurus with this custom-designed visualization featuring packed circles, collision resolution, and navigation.",
     "link": "/packed-radial-tree",
     "image": {
@@ -55,7 +55,7 @@
     }
   },
   {
-    "title": "When David Meets Goliath: Using Smartwatches and Large Displays Together for Data Analysis",
+    "title": "Using Smartwatches and Large Displays Together for Data Analysis",
     "abstract": "New conceptual framework developed at University of Maryland and Technische Universität Dresden helps utilize multiple devices together for visual data analysis.",
     "link": "http://hcil.umd.edu/when-david-meets-goliath-using-smartwatches-and-large-displays-together-for-data-analysis/",
     "video": "https://www.youtube.com/watch?v=DYSvA_Hn39o",

--- a/src/data/posts.json
+++ b/src/data/posts.json
@@ -1,7 +1,7 @@
 {
   "posts": [
     {
-      "title": "Exploring Complex Hierarchies",
+      "title": "Exploring Complex Hierarchies with Packed Radial Tree",
       "abstract": "An interactive visualization that renders hierarchical datasets as elegantly-arranged circular nodes in a radial layout. Explore the Unified Astronomy Thesaurus with this custom-designed visualization featuring packed circles, collision resolution, and navigation.",
       "link": "/packed-radial-tree",
       "type": "Interactive Demo",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -11,8 +11,14 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { Page } from "../components/Page";
+import { useColorModeValue } from "../components/ui/color-mode";
+import { accentSubtle } from "../theme";
 
 export const About = () => {
+  const subtleHeadingColor = useColorModeValue(
+    accentSubtle.light,
+    accentSubtle.dark
+  );
   const experiences = [
     {
       title: "Staff Full Stack Engineer",
@@ -34,7 +40,7 @@ export const About = () => {
     <Page>
       <Container maxW="72ch" pb={4}>
         <VStack gap={4} align="stretch">
-          <Heading>About Me</Heading>
+          <Heading color={subtleHeadingColor}>About Me</Heading>
           <Box>
             <Text fontSize="md" mb={4}>
               Full-stack engineer building tools for data exploration and ML
@@ -50,13 +56,13 @@ export const About = () => {
           </Box>
 
           <Box>
-            <Heading size="lg" mb={4}>
+            <Heading size="lg" mb={4} color={subtleHeadingColor}>
               Experience
             </Heading>
             <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
               {experiences.map((exp, index) => (
                 <Stack key={index} p={4} borderWidth="1px" borderRadius="lg">
-                  <Heading size="md">{exp.title}</Heading>
+                  <Heading size="md" color={subtleHeadingColor}>{exp.title}</Heading>
                   <Flex gap={2}>
                     <Text fontWeight="medium">{exp.company}</Text>
                     <Separator orientation="vertical" />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -11,14 +11,8 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { Page } from "../components/Page";
-import { useColorModeValue } from "../components/ui/color-mode";
-import { accentSubtle } from "../theme";
 
 export const About = () => {
-  const subtleHeadingColor = useColorModeValue(
-    accentSubtle.light,
-    accentSubtle.dark
-  );
   const experiences = [
     {
       title: "Staff Full Stack Engineer",
@@ -40,7 +34,7 @@ export const About = () => {
     <Page>
       <Container maxW="72ch" pb={4}>
         <VStack gap={4} align="stretch">
-          <Heading color={subtleHeadingColor}>About Me</Heading>
+          <Heading color="accent">About Me</Heading>
           <Box>
             <Text fontSize="md" mb={4}>
               Full-stack engineer building tools for data exploration and ML
@@ -49,20 +43,22 @@ export const About = () => {
             </Text>
             <Text fontSize="md" mb={4}>
               Get in touch:{" "}
-              <Link href="mailto:karthikbadam7@gmail.com" color="blue.500">
-                karthikbadam7@gmail.com
+              <Link href="mailto:karthikbadam7@gmail.com" color="accent">
+                karthikbadam7 [at] gmail.com
               </Link>
             </Text>
           </Box>
 
           <Box>
-            <Heading size="lg" mb={4} color={subtleHeadingColor}>
+            <Heading size="lg" mb={4} color="accentSubtle">
               Experience
             </Heading>
             <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
               {experiences.map((exp, index) => (
                 <Stack key={index} p={4} borderWidth="1px" borderRadius="lg">
-                  <Heading size="md" color={subtleHeadingColor}>{exp.title}</Heading>
+                  <Heading size="md" color="accent">
+                    {exp.title}
+                  </Heading>
                   <Flex gap={2}>
                     <Text fontWeight="medium">{exp.company}</Text>
                     <Separator orientation="vertical" />

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -12,6 +12,8 @@ import {
 import React from "react";
 import { useParams } from "react-router-dom";
 import { Page } from "../components/Page";
+import { accent } from "../theme";
+import { useColorModeValue } from "../components/ui/color-mode";
 
 // Import all blog posts
 import UnderstandingEmbeddings from "../content/blog/understanding-embeddings.mdx";
@@ -26,8 +28,10 @@ interface MDXComponentProps extends React.HTMLAttributes<HTMLElement> {
   href?: string;
 }
 
-const components = {
-  h1: (props: HeadingProps) => <Heading as="h1" size="2xl" mb={8} {...props} />,
+const createComponents = (headingColor: string) => ({
+  h1: (props: HeadingProps) => (
+    <Heading as="h1" size="2xl" mb={8} color={headingColor} {...props} />
+  ),
   h2: (props: HeadingProps) => (
     <Heading
       as="h2"
@@ -79,10 +83,12 @@ const components = {
     <Box as="ol" mb={4} ml={6} listStyleType="decimal" {...props} />
   ),
   li: (props: MDXComponentProps) => <ListItem mb={2} {...props} />,
-};
+});
 
 export const BlogPost: React.FC = () => {
   const { slug } = useParams<{ slug: string }>();
+  const headingColor = useColorModeValue(accent.light, accent.dark);
+  const components = createComponents(headingColor);
   const Post = blogPosts[slug as keyof typeof blogPosts];
 
   if (!Post) {

--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -15,9 +15,8 @@ import {
   TreeNode,
 } from "@kvis/packed-radial-tree";
 import { useEffect, useState } from "react";
-import { useColorMode, useColorModeValue } from "../../components/ui/color-mode";
-import { accent } from "../../theme";
 import { Page } from "../../components/Page";
+import { useColorMode } from "../../components/ui/color-mode";
 
 const parseUATData = async (): Promise<TreeNode> => {
   try {
@@ -105,8 +104,7 @@ export function PackedRadialTreeDemo() {
   const [uatData, setUatData] = useState<TreeNode | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const { colorMode } = useColorMode();
-  const headingColor = useColorModeValue(accent.light, accent.dark);
-
+  
   const config: Partial<PackedTreeOptions> = {
     maxDepth: 2,
     isInterleaved: true,
@@ -159,7 +157,7 @@ export function PackedRadialTreeDemo() {
           justifyContent="center"
         >
           <VStack gap={4}>
-            <Heading color={headingColor}>
+            <Heading color='accent'>
               Loading UAT Dataset...
             </Heading>
             <Text color="gray.fg">
@@ -201,7 +199,7 @@ export function PackedRadialTreeDemo() {
           <Stack gap={10}>
             {/* Header */}
             <Box>
-              <Heading as="h1" size="2xl" color={headingColor}>
+              <Heading as="h1" size="2xl" color='accent'>
                 Packed Radial Tree
               </Heading>
               <Text fontSize="xs" color="gray.focusRing" mb={4}>
@@ -225,7 +223,6 @@ export function PackedRadialTreeDemo() {
                   as="h2"
                   size="md"
                   mb={1}
-                  color={headingColor}
                 >
                   Selected Concept
                 </Heading>
@@ -314,7 +311,6 @@ export function PackedRadialTreeDemo() {
                   as="h2"
                   size="md"
                   mb={1}
-                  color={headingColor}
                 >
                   Interaction Guide
                 </Heading>

--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -15,7 +15,8 @@ import {
   TreeNode,
 } from "@kvis/packed-radial-tree";
 import { useEffect, useState } from "react";
-import { useColorMode } from "../../components/ui/color-mode";
+import { useColorMode, useColorModeValue } from "../../components/ui/color-mode";
+import { accent } from "../../theme";
 import { Page } from "../../components/Page";
 
 const parseUATData = async (): Promise<TreeNode> => {
@@ -104,6 +105,7 @@ export function PackedRadialTreeDemo() {
   const [uatData, setUatData] = useState<TreeNode | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const { colorMode } = useColorMode();
+  const headingColor = useColorModeValue(accent.light, accent.dark);
 
   const config: Partial<PackedTreeOptions> = {
     maxDepth: 2,
@@ -157,7 +159,9 @@ export function PackedRadialTreeDemo() {
           justifyContent="center"
         >
           <VStack gap={4}>
-            <Heading>Loading UAT Dataset...</Heading>
+            <Heading color={headingColor}>
+              Loading UAT Dataset...
+            </Heading>
             <Text color="gray.fg">
               Parsing hierarchical astronomy taxonomy data
             </Text>
@@ -197,7 +201,7 @@ export function PackedRadialTreeDemo() {
           <Stack gap={10}>
             {/* Header */}
             <Box>
-              <Heading as="h1" size="2xl">
+              <Heading as="h1" size="2xl" color={headingColor}>
                 Packed Radial Tree
               </Heading>
               <Text fontSize="xs" color="gray.focusRing" mb={4}>
@@ -217,7 +221,12 @@ export function PackedRadialTreeDemo() {
             {/* Selected Node Details */}
             {selectedNode ? (
               <Box>
-                <Heading as="h2" size="md" mb={1}>
+                <Heading
+                  as="h2"
+                  size="md"
+                  mb={1}
+                  color={headingColor}
+                >
                   Selected Concept
                 </Heading>
                 <VStack gap={4} align="stretch">
@@ -301,7 +310,12 @@ export function PackedRadialTreeDemo() {
               </Box>
             ) : (
               <Box>
-                <Heading as="h2" size="md" mb={1}>
+                <Heading
+                  as="h2"
+                  size="md"
+                  mb={1}
+                  color={headingColor}
+                >
                   Interaction Guide
                 </Heading>
                 <VStack gap={2} align="stretch">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,8 +13,8 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import { useColorModeValue } from "../components/ui/color-mode";
-import { accent, accentSubtle } from "../theme";
 import featuredData from "../data/featured.json";
+import { accent } from "../theme";
 
 // Define types for the post data
 interface Post {
@@ -40,7 +40,6 @@ interface Post {
 
 export const Home = () => {
   const highlightColor = useColorModeValue(accent.light, accent.dark);
-  const subtleHeadingColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
   const featuredPosts = (featuredData as Post[]).filter(
     (post) => post.featured
   );
@@ -50,7 +49,7 @@ export const Home = () => {
     <Page>
       <Container maxW="container.xl" px={8}>
         <Grid
-          templateColumns={{ base: "1fr", md: "300px 1fr" }}
+          templateColumns={{ base: "1fr", md: "320px 1fr" }}
           gap="100px"
           minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
           mx="auto"
@@ -72,7 +71,6 @@ export const Home = () => {
                 maxWidth="150px"
                 height="auto"
                 objectFit="cover"
-                boxShadow="2xl"
                 transition="transform 0.3s"
                 _hover={{ transform: "scale(1.05)" }}
               />
@@ -108,7 +106,7 @@ export const Home = () => {
           </Stack>
           <Stack py={2}>
             <Stack gap={4} maxW={{ base: "100%", lg: "80ch" }}>
-              <Heading size="xl" color={subtleHeadingColor}>
+              <Heading size="xl" color="accent">
                 Featured Works
               </Heading>
               {/* Featured Posts as Large Cards - Side by Side */}
@@ -222,10 +220,10 @@ const FeaturedCard = ({ post, image }: FeaturedCardProps) => (
       height="200px"
     />
     <Stack gap={2} flex="1">
-      <Heading size="md" fontWeight="medium">
+      <Heading size="md" fontWeight="medium" color="accent">
         {post.title}
       </Heading>
-      <Text color="gray.focusRing" fontSize="sm" lineClamp={3}>
+      <Text fontSize="sm" lineClamp={3} color="gray.focusRing">
         {post.abstract}
       </Text>
       <HStack gap={2} pt={2}>
@@ -264,10 +262,10 @@ const PostCard = ({ post }: PostCardProps) => (
     h="100%"
   >
     <Stack gap={2}>
-      <Heading size="md" fontWeight="medium">
+      <Heading size="md" fontWeight="medium" color="accent">
         {post.title}
       </Heading>
-      <Text color="gray.focusRing" fontSize="sm" lineClamp={3}>
+      <Text color="gray.focusRing" fontSize="sm" lineClamp={2}>
         {post.abstract}
       </Text>
       <HStack gap={2} pt={2}>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { accent, accentSubtle } from "../theme";
 import featuredData from "../data/featured.json";
 
 // Define types for the post data
@@ -38,7 +39,8 @@ interface Post {
 }
 
 export const Home = () => {
-  const highlightColor = useColorModeValue("#6e5d44", "#DFD0B8");
+  const highlightColor = useColorModeValue(accent.light, accent.dark);
+  const subtleHeadingColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
   const featuredPosts = (featuredData as Post[]).filter(
     (post) => post.featured
   );
@@ -106,7 +108,9 @@ export const Home = () => {
           </Stack>
           <Stack py={2}>
             <Stack gap={4} maxW={{ base: "100%", lg: "80ch" }}>
-              <Heading size="xl">Featured Works</Heading>
+              <Heading size="xl" color={subtleHeadingColor}>
+                Featured Works
+              </Heading>
               {/* Featured Posts as Large Cards - Side by Side */}
               {featuredPosts.length > 0 && (
                 <Grid

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -1,18 +1,16 @@
 import {
+  Box,
+  Button,
+  Link as ChakraLink,
   Container,
   Heading,
-  VStack,
-  Text,
-  Box,
-  Link as ChakraLink,
-  Button,
   HStack,
+  Text,
+  VStack,
 } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import postsData from "../data/posts.json";
-import { useColorModeValue } from "../components/ui/color-mode";
-import { accentSubtle, accent } from "../theme";
 
 interface Post {
   title: string;
@@ -24,9 +22,7 @@ interface Post {
 
 export const Posts = () => {
   const { posts } = postsData as { posts: Post[] };
-  const highlightColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
-  const buttonHoverBg = useColorModeValue(accent.light, accent.dark);
-  
+
   // Helper function to determine if a link is internal or external
   const isInternalLink = (url: string): boolean => {
     return (
@@ -38,7 +34,7 @@ export const Posts = () => {
     <Page>
       <Container maxW="100ch" pb={4}>
         <VStack gap={4} align="stretch">
-          <Heading color={highlightColor}>Posts</Heading>
+          <Heading color="accent">Posts</Heading>
           {posts.map((post, index) => (
             <Box
               key={index}
@@ -47,7 +43,7 @@ export const Posts = () => {
               borderRadius="lg"
               fontSize="sm"
             >
-              <Heading size="md" color={highlightColor}>
+              <Heading size="md" color="accent">
                 {post.title}
               </Heading>
               <Text color="gray.fg" mt={2}>
@@ -60,9 +56,9 @@ export const Posts = () => {
                     <Button
                       size="sm"
                       variant="outline"
-                      color={highlightColor}
-                      borderColor={highlightColor}
-                      _hover={{ bg: buttonHoverBg, color: "white" }}
+                      color="accent"
+                      borderColor="accent"
+                      _hover={{ bg: "accentSubtle", color: "gray.contrast" }}
                     >
                       Read More
                     </Button>
@@ -76,9 +72,9 @@ export const Posts = () => {
                     <Button
                       size="sm"
                       variant="outline"
-                      color={highlightColor}
-                      borderColor={highlightColor}
-                      _hover={{ bg: buttonHoverBg, color: "white" }}
+                      color="accent"
+                      borderColor="accent"
+                      _hover={{ bg: "accentSubtle", color: "gray.contrast" }}
                     >
                       Read More
                     </Button>
@@ -93,9 +89,9 @@ export const Posts = () => {
                     <Button
                       size="sm"
                       variant="outline"
-                      color={highlightColor}
-                      borderColor={highlightColor}
-                      _hover={{ bg: buttonHoverBg, color: "white" }}
+                      color="accent"
+                      borderColor="accent"
+                      _hover={{ bg: "accentSubtle", color: "gray.contrast" }}
                     >
                       Watch Video
                     </Button>

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -12,6 +12,7 @@ import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
 import postsData from "../data/posts.json";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { accentSubtle, accent } from "../theme";
 
 interface Post {
   title: string;
@@ -23,8 +24,9 @@ interface Post {
 
 export const Posts = () => {
   const { posts } = postsData as { posts: Post[] };
-  const highlightColor = useColorModeValue("#6e5d44", "#DFD0B8");
-
+  const highlightColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
+  const buttonHoverBg = useColorModeValue(accent.light, accent.dark);
+  
   // Helper function to determine if a link is internal or external
   const isInternalLink = (url: string): boolean => {
     return (
@@ -36,7 +38,7 @@ export const Posts = () => {
     <Page>
       <Container maxW="100ch" pb={4}>
         <VStack gap={4} align="stretch">
-          <Heading>Posts</Heading>
+          <Heading color={highlightColor}>Posts</Heading>
           {posts.map((post, index) => (
             <Box
               key={index}
@@ -55,7 +57,13 @@ export const Posts = () => {
               <HStack mt={2} gap={4}>
                 {isInternalLink(post.link) ? (
                   <RouterLink to={post.link}>
-                    <Button size="sm" variant="outline">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      color={highlightColor}
+                      borderColor={highlightColor}
+                      _hover={{ bg: buttonHoverBg, color: "white" }}
+                    >
                       Read More
                     </Button>
                   </RouterLink>
@@ -65,7 +73,13 @@ export const Posts = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <Button size="sm" variant="outline">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      color={highlightColor}
+                      borderColor={highlightColor}
+                      _hover={{ bg: buttonHoverBg, color: "white" }}
+                    >
                       Read More
                     </Button>
                   </ChakraLink>
@@ -76,7 +90,13 @@ export const Posts = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <Button size="sm" variant="outline">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      color={highlightColor}
+                      borderColor={highlightColor}
+                      _hover={{ bg: buttonHoverBg, color: "white" }}
+                    >
                       Watch Video
                     </Button>
                   </ChakraLink>

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -13,13 +13,17 @@ import {
 import { FormEvent, useState } from "react";
 import { Page } from "../components/Page";
 import { useColorModeValue } from "../components/ui/color-mode";
+import { accent, accentSubtle } from "../theme";
 import publicationsData from "../data/publications.json";
 
 export const Publications = () => {
   const [selectedType, setSelectedType] = useState<string>("all");
   const [selectedYear, setSelectedYear] = useState<string>("all");
 
-  const highlightColor = useColorModeValue("#6e5d44", "#DFD0B8");
+  const highlightColor = useColorModeValue(accent.light, accent.dark);
+  const subtleHeadingColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
+  const buttonColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
+  const buttonHoverBg = useColorModeValue(accent.light, accent.dark);
 
   // Get unique types and years for filters
   const types = [
@@ -76,7 +80,7 @@ export const Publications = () => {
     <Page>
       <Container maxW="100ch" pb={4}>
         <VStack gap={4} align="stretch">
-          <Heading>Publications</Heading>
+          <Heading color={subtleHeadingColor}>Publications</Heading>
 
           {/* Filters */}
           <Flex gap={4} wrap="wrap">
@@ -111,7 +115,7 @@ export const Publications = () => {
           {/* Publications List by Type */}
           {Object.entries(groupedPublications).map(([type, pubs]) => (
             <Box key={type} fontSize='sm'>
-              <Heading size="md" mb={2}>
+              <Heading size="md" mb={2} color={subtleHeadingColor}>
                 {type.charAt(0).toUpperCase() + type.slice(1)}
               </Heading>
               {pubs.map((pub, index) => (
@@ -134,7 +138,7 @@ export const Publications = () => {
                           color: "inherit",
                         }}
                       >
-                        <Heading size="md">{pub.title}</Heading>
+                        <Heading size="md" color={buttonColor}>{pub.title}</Heading>
                       </a>
                       <Text fontWeight="semibold">{pub.year}</Text>
                     </Flex>
@@ -160,9 +164,9 @@ export const Publications = () => {
                           py={1}
                           borderRadius="md"
                           borderWidth="1px"
-                          borderColor="blue.subtle"
-                          color="white"
-                          bg="blue.solid"
+                          borderColor={buttonColor}
+                          color={buttonColor}
+                          _hover={{ bg: buttonHoverBg, color: "white" }}
                         >
                           PDF
                         </Link>
@@ -176,9 +180,9 @@ export const Publications = () => {
                           py={1}
                           borderRadius="md"
                           borderWidth="1px"
-                          borderColor="orange.subtle"
-                          color="white"
-                          bg="orange.solid"
+                          borderColor={buttonColor}
+                          color={buttonColor}
+                          _hover={{ bg: buttonHoverBg, color: "white" }}
                         >
                           Video
                         </Link>

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -1,29 +1,24 @@
 import {
   Box,
+  Button,
   Container,
   Flex,
   Heading,
   Link,
   NativeSelect,
   Separator,
+  Stack,
   Tag,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { FormEvent, useState } from "react";
 import { Page } from "../components/Page";
-import { useColorModeValue } from "../components/ui/color-mode";
-import { accent, accentSubtle } from "../theme";
 import publicationsData from "../data/publications.json";
 
 export const Publications = () => {
   const [selectedType, setSelectedType] = useState<string>("all");
   const [selectedYear, setSelectedYear] = useState<string>("all");
-
-  const highlightColor = useColorModeValue(accent.light, accent.dark);
-  const subtleHeadingColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
-  const buttonColor = useColorModeValue(accentSubtle.light, accentSubtle.dark);
-  const buttonHoverBg = useColorModeValue(accent.light, accent.dark);
 
   // Get unique types and years for filters
   const types = [
@@ -65,7 +60,7 @@ export const Publications = () => {
     return authors.map((author, idx) => (
       <span key={idx}>
         {author === "Sriram Karthik Badam" ? (
-          <Text as="span" color={highlightColor} fontWeight="semibold">
+          <Text as="span" color="accent" fontWeight="medium">
             {author}
           </Text>
         ) : (
@@ -80,7 +75,7 @@ export const Publications = () => {
     <Page>
       <Container maxW="100ch" pb={4}>
         <VStack gap={4} align="stretch">
-          <Heading color={subtleHeadingColor}>Publications</Heading>
+          <Heading color="accent">Publications</Heading>
 
           {/* Filters */}
           <Flex gap={4} wrap="wrap">
@@ -114,8 +109,8 @@ export const Publications = () => {
 
           {/* Publications List by Type */}
           {Object.entries(groupedPublications).map(([type, pubs]) => (
-            <Box key={type} fontSize='sm'>
-              <Heading size="md" mb={2} color={subtleHeadingColor}>
+            <Box key={type} fontSize="sm">
+              <Heading size="md" mb={2} color="accentSubtle">
                 {type.charAt(0).toUpperCase() + type.slice(1)}
               </Heading>
               {pubs.map((pub, index) => (
@@ -127,48 +122,59 @@ export const Publications = () => {
                   borderColor="gray.muted"
                   mb={2}
                 >
-                  <VStack align="stretch" gap={2}>
-                    <Flex justify="space-between" align="center">
-                      <a
-                        href={pub.pdf}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{
-                          textDecoration: "none",
-                          color: "inherit",
-                        }}
-                      >
-                        <Heading size="md" color={buttonColor}>{pub.title}</Heading>
-                      </a>
-                      <Text fontWeight="semibold">{pub.year}</Text>
-                    </Flex>
-                    <Text>{renderAuthors(pub.authors)}</Text>
-                   
-                    <Flex gap={2} wrap="wrap">
-                      <Text color={highlightColor} fontWeight="semibold">{pub.venue}</Text>
-                      {pub.award && (
+                  <Flex justify="space-between" gap={4}>
+                    <Stack gap={2}>
+                      <Heading size="md" color="accent">
+                        {pub.title}
+                      </Heading>
+                      <Flex>
+                        <Text>{renderAuthors(pub.authors)}</Text>
+                      </Flex>
+                      <Flex gap={2} wrap="wrap">
+                        <Text>{pub.venue}</Text>
+                        {pub.award && (
+                          <>
+                            <Separator orientation="vertical" />
+                            <Text color="purple.fg">
+                              {pub.award}
+                            </Text>
+                          </>
+                        )}
                         <>
                           <Separator orientation="vertical" />
-                          <Text color="purple.fg">{pub.award}</Text>
+                          <Text>{pub.year}</Text>
                         </>
+                      </Flex>
+                      {pub.keywords && pub.keywords.length > 0 && (
+                        <Flex gap={2} wrap="wrap">
+                          {pub.keywords.map((keyword, idx) => (
+                            <Tag.Root key={idx} fontSize="sm">
+                              <Tag.Label>{keyword}</Tag.Label>
+                            </Tag.Root>
+                          ))}
+                        </Flex>
                       )}
-                    </Flex>
-
-                    <Flex gap={2}>
+                    </Stack>
+                    <Stack>
                       {pub.pdf && (
                         <Link
                           href={pub.pdf}
                           target="_blank"
                           rel="noopener noreferrer"
-                          px={2}
-                          py={1}
-                          borderRadius="md"
-                          borderWidth="1px"
-                          borderColor={buttonColor}
-                          color={buttonColor}
-                          _hover={{ bg: buttonHoverBg, color: "white" }}
                         >
-                          PDF
+                          <Button
+                            size="sm"
+                            minW="70px"
+                            variant="outline"
+                            color="accent"
+                            borderColor="accent"
+                            _hover={{
+                              bg: "accentSubtle",
+                              color: "gray.contrast",
+                            }}
+                          >
+                            PDF
+                          </Button>
                         </Link>
                       )}
                       {pub.video && (
@@ -176,28 +182,24 @@ export const Publications = () => {
                           href={pub.video}
                           target="_blank"
                           rel="noopener noreferrer"
-                          px={2}
-                          py={1}
-                          borderRadius="md"
-                          borderWidth="1px"
-                          borderColor={buttonColor}
-                          color={buttonColor}
-                          _hover={{ bg: buttonHoverBg, color: "white" }}
                         >
-                          Video
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            minW="70px"
+                            color="accent"
+                            borderColor="accent"
+                            _hover={{
+                              bg: "accentSubtle",
+                              color: "gray.contrast",
+                            }}
+                          >
+                            Video
+                          </Button>
                         </Link>
                       )}
-                    </Flex>
-                    {pub.keywords && pub.keywords.length > 0 && (
-                      <Flex gap={2} wrap="wrap">
-                        {pub.keywords.map((keyword, idx) => (
-                          <Tag.Root key={idx} fontSize="sm">
-                            <Tag.Label>{keyword}</Tag.Label>
-                          </Tag.Root>
-                        ))}
-                      </Flex>
-                    )}
-                  </VStack>
+                    </Stack>
+                  </Flex>
                 </Box>
               ))}
             </Box>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "@chakra-ui/react";
+import { textStyles } from "./components/ui/textStyles";
+
+export const accent = {
+  light: "#6e5d44",
+  dark: "#DFD0B8",
+};
+
+export const accentSubtle = {
+  light: "#A08E74",
+  dark: "#E8E0D0",
+};
+
+export const theme = defineConfig({
+  theme: {
+    textStyles,
+    semanticTokens: {
+      colors: {
+        accent: {
+          value: { _light: accent.light, _dark: accent.dark },
+        },
+        accentSubtle: {
+          value: { _light: accentSubtle.light, _dark: accentSubtle.dark },
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- refine accent tokens and add accentSubtle palette
- make Posts highlights more muted
- tint headings across pages with accent colors
- style demo page headings with accent
- adjust Publications buttons to use accent palette

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d605b7f4832196bf2407a1a54d01