### PR TITLE
Enable light and dark Prism themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,2 +1,3 @@
 @import './styles/mdx.css';
-@import './styles/prism-theme.css';
+@import './styles/prism-light.css';
+@import './styles/prism-dark.css';

--- a/src/styles/prism-dark.css
+++ b/src/styles/prism-dark.css
@@ -3,8 +3,8 @@
  * Based on Atom's One Dark theme: https://github.com/atom/atom/tree/master/packages/one-dark-syntax
  */
 
-code[class*="language-"],
-pre[class*="language-"] {
+html.dark code[class*="language-"],
+html.dark pre[class*="language-"] {
   color: #abb2bf;
   background: none;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
@@ -18,120 +18,120 @@ pre[class*="language-"] {
   hyphens: none;
 }
 
-pre[class*="language-"] {
+html.dark pre[class*="language-"] {
   padding: 1em;
   margin: .5em 0;
   overflow: auto;
   border-radius: 0.3em;
 }
 
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
+html.dark :not(pre) > code[class*="language-"],
+html.dark pre[class*="language-"] {
   background: #282c34;
 }
 
 /* Inline code */
-:not(pre) > code[class*="language-"] {
+html.dark :not(pre) > code[class*="language-"] {
   padding: .1em;
   border-radius: .3em;
   white-space: normal;
 }
 
-.token.comment,
-.token.prolog,
-.token.doctype,
-.token.cdata {
+html.dark .token.comment,
+html.dark .token.prolog,
+html.dark .token.doctype,
+html.dark .token.cdata {
   color: #5c6370;
 }
 
-.token.punctuation {
+html.dark .token.punctuation {
   color: #abb2bf;
 }
 
-.token.selector,
-.token.tag {
+html.dark .token.selector,
+html.dark .token.tag {
   color: #e06c75;
 }
 
-.token.property,
-.token.boolean,
-.token.number,
-.token.constant,
-.token.symbol,
-.token.attr-name,
-.token.deleted {
+html.dark .token.property,
+html.dark .token.boolean,
+html.dark .token.number,
+html.dark .token.constant,
+html.dark .token.symbol,
+html.dark .token.attr-name,
+html.dark .token.deleted {
   color: #d19a66;
 }
 
-.token.string,
-.token.char,
-.token.attr-value,
-.token.builtin,
-.token.inserted {
+html.dark .token.string,
+html.dark .token.char,
+html.dark .token.attr-value,
+html.dark .token.builtin,
+html.dark .token.inserted {
   color: #98c379;
 }
 
-.token.operator,
-.token.entity,
-.token.url,
-.language-css .token.string,
-.style .token.string {
+html.dark .token.operator,
+html.dark .token.entity,
+html.dark .token.url,
+html.dark .language-css .token.string,
+html.dark .style .token.string {
   color: #56b6c2;
 }
 
-.token.atrule,
-.token.keyword {
+html.dark .token.atrule,
+html.dark .token.keyword {
   color: #c678dd;
 }
 
-.token.function {
+html.dark .token.function {
   color: #61afef;
 }
 
-.token.regex,
-.token.important,
-.token.variable {
+html.dark .token.regex,
+html.dark .token.important,
+html.dark .token.variable {
   color: #c678dd;
 }
 
-.token.important,
-.token.bold {
+html.dark .token.important,
+html.dark .token.bold {
   font-weight: bold;
 }
 
-.token.italic {
+html.dark .token.italic {
   font-style: italic;
 }
 
-.token.entity {
+html.dark .token.entity {
   cursor: help;
 }
 
 /* Line highlighting */
-.line-highlight {
+html.dark .line-highlight {
   background: rgba(153, 153, 153, 0.2);
   background: linear-gradient(to right, rgba(153, 153, 153, 0.2) 70%, rgba(153, 153, 153, 0));
 }
 
-.line-highlight:before, 
-.line-highlight[data-end]:after {
+html.dark .line-highlight:before, 
+html.dark .line-highlight[data-end]:after {
   background-color: #3b4048;
   color: #abb2bf;
 }
 
 /* Line numbers */
-pre[class*="language-"].line-numbers {
+html.dark pre[class*="language-"].line-numbers {
   position: relative;
   padding-left: 3.8em;
   counter-reset: linenumber;
 }
 
-pre[class*="language-"].line-numbers > code {
+html.dark pre[class*="language-"].line-numbers > code {
   position: relative;
   white-space: inherit;
 }
 
-.line-numbers .line-numbers-rows {
+html.dark .line-numbers .line-numbers-rows {
   position: absolute;
   pointer-events: none;
   top: 0;
@@ -143,13 +143,13 @@ pre[class*="language-"].line-numbers > code {
   user-select: none;
 }
 
-.line-numbers-rows > span {
+html.dark .line-numbers-rows > span {
   pointer-events: none;
   display: block;
   counter-increment: linenumber;
 }
 
-.line-numbers-rows > span:before {
+html.dark .line-numbers-rows > span:before {
   content: counter(linenumber);
   color: #5c6370;
   display: block;

--- a/src/styles/prism-light.css
+++ b/src/styles/prism-light.css
@@ -1,0 +1,140 @@
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+html.light code[class*="language-"],
+html.light pre[class*="language-"] {
+	color: black;
+	background: none;
+	text-shadow: 0 1px white;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+html.light pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+html.light code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+html.light pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+html.light code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+@media print {
+html.light 	code[class*="language-"],
+html.light 	pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+/* Code blocks */
+html.light pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+html.light :not(pre) > code[class*="language-"],
+html.light pre[class*="language-"] {
+	background: #f5f2f0;
+}
+
+/* Inline code */
+html.light :not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+html.light .token.comment,
+html.light .token.prolog,
+html.light .token.doctype,
+html.light .token.cdata {
+	color: slategray;
+}
+
+html.light .token.punctuation {
+	color: #999;
+}
+
+html.light .token.namespace {
+	opacity: .7;
+}
+
+html.light .token.property,
+html.light .token.tag,
+html.light .token.boolean,
+html.light .token.number,
+html.light .token.constant,
+html.light .token.symbol,
+html.light .token.deleted {
+	color: #905;
+}
+
+html.light .token.selector,
+html.light .token.attr-name,
+html.light .token.string,
+html.light .token.char,
+html.light .token.builtin,
+html.light .token.inserted {
+	color: #690;
+}
+
+html.light .token.operator,
+html.light .token.entity,
+html.light .token.url,
+html.light .language-css .token.string,
+html.light .style .token.string {
+	color: #9a6e3a;
+	/* This background color was intended by the author of this theme. */
+	background: hsla(0, 0%, 100%, .5);
+}
+
+html.light .token.atrule,
+html.light .token.attr-value,
+html.light .token.keyword {
+	color: #07a;
+}
+
+html.light .token.function,
+html.light .token.class-name {
+	color: #DD4A68;
+}
+
+html.light .token.regex,
+html.light .token.important,
+html.light .token.variable {
+	color: #e90;
+}
+
+html.light .token.important,
+html.light .token.bold {
+	font-weight: bold;
+}
+html.light .token.italic {
+	font-style: italic;
+}
+
+html.light .token.entity {
+	cursor: help;
+}

--- a/src/styles/prism-light.css
+++ b/src/styles/prism-light.css
@@ -8,9 +8,7 @@ html.light code[class*="language-"],
 html.light pre[class*="language-"] {
 	color: black;
 	background: none;
-	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;
@@ -18,9 +16,9 @@ html.light pre[class*="language-"] {
 	word-wrap: normal;
 	line-height: 1.5;
 
-	-moz-tab-size: 4;
-	-o-tab-size: 4;
-	tab-size: 4;
+	-moz-tab-size: 2;
+	-o-tab-size: 2;
+	tab-size: 2;
 
 	-webkit-hyphens: none;
 	-moz-hyphens: none;


### PR DESCRIPTION
## Summary
- add Prism theme scoped to light mode
- scope existing dark theme to the dark class
- import both themes in global CSS

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dac4ce9bc83218c873f4c06ca4902