### PR TITLE
Refactor pages to use TwoPanelWithScroll layout

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,7 +19,7 @@ export const Navbar = () => {
   });
 
   return (
-    <Box px={{ base: 4, md: 10 }} py={2} fontSize="sm">
+    <Box px={{ base: 4, md: 8 }} py={2} fontSize="sm">
       <Flex h={10} alignItems="center" justifyContent="space-between">
         <Link
           to="/"

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -15,7 +15,7 @@ export const Page = ({ children }: PageProps) => {
       </Box>
 
       {/* Main Content */}
-      <Box as="main" flex="1" overflowY="auto">
+      <Box py={2} as="main" flex="1" overflowY="auto">
         {children}
       </Box>
 

--- a/src/components/TwoPanelWithScroll.tsx
+++ b/src/components/TwoPanelWithScroll.tsx
@@ -1,0 +1,56 @@
+import { Grid, GridProps, Box, BoxProps } from "@chakra-ui/react";
+import { ReactNode, Children } from "react";
+
+interface TwoPanelWithScrollProps extends Omit<GridProps, "children"> {
+  /** Width of left panel at md breakpoint and above */
+  leftWidth?: string | number;
+  /** Width of right panel at md breakpoint and above */
+  rightWidth?: string | number;
+  children: ReactNode;
+}
+
+interface PanelProps extends BoxProps {
+  children: ReactNode;
+}
+
+const LeftPanel = ({ children, ...rest }: PanelProps) => (
+  <Box
+    position={{ base: "static", md: "sticky" }}
+    top={{ base: "auto", md: 0 }}
+    height={{ base: "auto", md: "fit-content" }}
+    alignSelf={{ base: "stretch", md: "start" }}
+    {...rest}
+  >
+    {children}
+  </Box>
+);
+
+const RightPanel = ({ children, ...rest }: PanelProps) => <Box {...rest}>{children}</Box>;
+
+const TwoPanelWithScrollComponent = ({
+  children,
+  leftWidth = "320px",
+  rightWidth = "1fr",
+  gap = 6,
+  ...rest
+}: TwoPanelWithScrollProps) => {
+  const [left, right] = Children.toArray(children);
+  return (
+    <Grid
+      templateColumns={{ base: "1fr", md: `${leftWidth} ${rightWidth}` }}
+      gap={gap}
+      minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
+      mx="auto"
+      w="fit-content"
+      {...rest}
+    >
+      {left}
+      {right}
+    </Grid>
+  );
+};
+
+export const TwoPanelWithScroll = Object.assign(TwoPanelWithScrollComponent, {
+  LeftPanel,
+  RightPanel,
+});

--- a/src/content/blog/understanding-embeddings.mdx
+++ b/src/content/blog/understanding-embeddings.mdx
@@ -13,7 +13,7 @@ In the world of Natural Language Processing (NLP), embeddings are like magical s
 
 ## What are Embeddings?
 
-Imagine you're in the Great Library of Tar Valon or the archives of the White Tower. Each book has its own unique characteristics: some are about the One Power, others about Allomancy, some focus on the history of Middle-earth, while others emphasize the Cosmere's magic systems. Embeddings work similarly - they capture these characteristics as numbers, allowing us to understand relationships between different pieces of text.
+Imagine you're in the Great Library of Tar Valon or the archives of the White Tower. Each book has its own unique characteristics: some are about the One Power, others about Allomancy, some focus on the history of Middle-earth, while others emphasize the Cosmere's magic systems. Embeddings work similarly by capturing these characteristics as numbers, allowing us to understand relationships between different pieces of text.
 
 ## Word2Vec: The Basic Magic System
 
@@ -34,7 +34,7 @@ print(model.wv.similarity('Kaladin', 'Frodo'))  # Similar heroes
 print(model.wv.similarity('Kaladin', 'Sauron'))  # Hero vs Villain
 ```
 
-Let's visualize how Word2Vec might represent some epic fantasy characters:
+If we show the Word2Vec numbers for some epic fantasy characters, they might look like this:
 
 <ScatterPlot
   data={[
@@ -48,7 +48,7 @@ Let's visualize how Word2Vec might represent some epic fantasy characters:
   title="Word2Vec: Character Relationships"
 />
 
-As we can see in the visualization, heroes naturally cluster together, while mentors form their own distinct group, and villains are cast far into the shadows. This mirrors how Word2Vec captures semantic relationships - characters with similar roles and traits end up closer in the embedding space, just like how similar words in a sentence tend to have similar embeddings.
+Heroes might naturally cluster together, while mentors form their own distinct group, and villains are cast far into the shadows. This captures how Word2Vec represents semantic relationships.
 
 ## BERT: The Advanced Magic System
 
@@ -96,11 +96,11 @@ Let's see how BERT might represent different fantasy concepts:
   title="BERT: Concept Relationships"
 />
 
-Looking at BERT's embeddings, we can see a clear separation between magic systems and artifacts, while maintaining relationships within each category. This is like how a skilled channeler can distinguish between different weaves of the One Power while understanding their underlying connections.
+If we plot BERT's embeddings, we might see a clear separation between magic systems and artifacts, while maintaining relationships within each category. This is like how a skilled channeler can distinguish between different weaves of the One Power while understanding their underlying connections.
 
 ## Visualizing Embeddings: The Art of Pattern Weaving
 
-Visualizing high-dimensional embeddings is like weaving the One Power into a spell or creating surges in the Cosmere - it transforms abstract concepts into tangible effects. Let's explore two powerful techniques:
+Visualizing high-dimensional embeddings is like weaving the One Power into a spell or creating surges in the Cosmere - it transforms abstract concepts into tangible effects. There are many ways to do this. Let's explore two powerful techniques:
 
 ### t-SNE: The Delicate Weave
 
@@ -195,10 +195,12 @@ umap_3d_results = reducer_3d.fit_transform(embeddings)
   title="UMAP: Fantasy Series Clustering"
 />
 
-In contrast to t-SNE, UMAP is like a powerful surge of Stormlight - it maintains both local and global structure more effectively. The clusters are more evenly distributed, and the relationships between different fantasy worlds are more clearly preserved. This makes it particularly useful when we need to understand both the fine details and the broader picture of our data.
+In contrast to t-SNE, UMAP is like a powerful surge of Stormlight. It can maintain both local and global structure more effectively. The clusters are more evenly distributed, and the relationships between different fantasy worlds are more clearly preserved. This makes it particularly useful when we need to understand both the fine details and the broader picture of our data.
 
 ## Conclusion
 
 Embeddings are powerful tools that help us understand and work with text in ways that were once thought impossible. Just as epic fantasy literature transports us to worlds of complex magic systems and deep lore, embeddings transform our understanding of language into a mathematical space where we can discover new relationships and insights.
 
-Remember, the next time you're reading about the Cosmere or Middle-earth, think about how each character, magic system, and artifact could be represented as an embedding - a point in a high-dimensional space that captures its essence and relationships with other elements in the story. The visualization techniques we've explored are like different ways of channeling the One Power or using Stormlight - each with its own strengths and characteristics, but all serving to make the abstract tangible and the complex understandable. 
+## Author's Note
+
+The embeddings and visualizations shown in this article are fictional. They are meant to represent the idea in a simple way. I would personally love to revisit this article with real embeddings and live magical weavings (i.e., charts) in the future!

--- a/src/data/featured.json
+++ b/src/data/featured.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Explore Complex Hierarchies",
+    "title": "Explore Astronomy Concepts",
     "abstract": "An interactive visualization that renders hierarchical datasets as elegantly-arranged circular nodes in a radial layout. Explore the Unified Astronomy Thesaurus with this custom-designed visualization featuring packed circles, collision resolution, and navigation.",
     "link": "/packed-radial-tree",
     "image": {

--- a/src/data/posts.json
+++ b/src/data/posts.json
@@ -1,7 +1,7 @@
 {
   "posts": [
     {
-      "title": "Exploring Complex Hierarchies with Packed Radial Tree",
+      "title": "Explore Astronomy Concepts with a Packed Radial Tree",
       "abstract": "An interactive visualization that renders hierarchical datasets as elegantly-arranged circular nodes in a radial layout. Explore the Unified Astronomy Thesaurus with this custom-designed visualization featuring packed circles, collision resolution, and navigation.",
       "link": "/packed-radial-tree",
       "type": "Interactive Demo",

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -38,7 +38,7 @@ const createComponents = (headingColor: string) => ({
       size="lg"
       mb={2}
       mt={8}
-      color="gray.focusRing"
+      color="accentSubtle"
       {...props}
     />
   ),
@@ -48,7 +48,7 @@ const createComponents = (headingColor: string) => ({
       size="md"
       mb={2}
       mt={8}
-      color="gray.focusRing"
+      color="accentSubtle"
       {...props}
     />
   ),

--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -2,7 +2,6 @@ import {
   Badge,
   Box,
   Button,
-  Grid,
   Heading,
   HStack,
   Link,
@@ -20,6 +19,7 @@ import {
 } from "@kvis/packed-radial-tree";
 import { useEffect, useState } from "react";
 import { Page } from "../../components/Page";
+import { TwoPanelWithScroll } from "../../components/TwoPanelWithScroll";
 import { useColorMode } from "../../components/ui/color-mode";
 import { LuExternalLink } from "react-icons/lu";
 
@@ -178,15 +178,9 @@ export function PackedRadialTreeDemo() {
 
   return (
     <Page>
-      {/* TODO: Fix the height hardcoding - inconsistent height values between Grid maxH and Box h */}
-      <Grid
-        templateColumns={{ base: "1fr", lg: "2fr 55ch" }}
-        overflowY="auto"
-        px={7}
-        gap={6}
-      >
+      <TwoPanelWithScroll leftWidth="2fr" rightWidth="55ch" px={7} gap={6}>
         {/* Left Column - Visualization (Full Height) */}
-        <Box h="75vh">
+        <TwoPanelWithScroll.LeftPanel h="75vh">
           {uatData && (
             <PackedRadialTree
               data={uatData}
@@ -194,10 +188,10 @@ export function PackedRadialTreeDemo() {
               options={config}
             />
           )}
-        </Box>
+        </TwoPanelWithScroll.LeftPanel>
 
         {/* Right Column - Content */}
-        <Box
+        <TwoPanelWithScroll.RightPanel
           maxW="72ch"
           mx="auto"
           pr={10}
@@ -404,8 +398,8 @@ export function PackedRadialTreeDemo() {
               </VStack>
             </Box>
           </Stack>
-        </Box>
-      </Grid>
+        </TwoPanelWithScroll.RightPanel>
+      </TwoPanelWithScroll>
     </Page>
   );
 }

--- a/src/pages/Demos/PRT.tsx
+++ b/src/pages/Demos/PRT.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   HStack,
   Link,
+  List,
   Stack,
   Text,
   VStack,
@@ -18,10 +19,10 @@ import {
   TreeNode,
 } from "@kvis/packed-radial-tree";
 import { useEffect, useState } from "react";
+import { LuExternalLink } from "react-icons/lu";
 import { Page } from "../../components/Page";
 import { TwoPanelWithScroll } from "../../components/TwoPanelWithScroll";
 import { useColorMode } from "../../components/ui/color-mode";
-import { LuExternalLink } from "react-icons/lu";
 
 const parseUATData = async (): Promise<TreeNode> => {
   try {
@@ -119,6 +120,7 @@ export function PackedRadialTreeDemo() {
     showLabels: true,
     showTooltips: true,
     colorMode,
+    sizeRange: [3, 60],
   };
 
   // Load UAT data
@@ -150,7 +152,7 @@ export function PackedRadialTreeDemo() {
     };
 
     traverse(node);
-    return descendants.slice(0, 20); // Limit to first 20 for display
+    return descendants.slice(0, 10); // Limit to first 10 for display
   };
 
   const descendants = selectedNode ? getDescendants(selectedNode) : [];
@@ -178,9 +180,9 @@ export function PackedRadialTreeDemo() {
 
   return (
     <Page>
-      <TwoPanelWithScroll leftWidth="2fr" rightWidth="55ch" px={7} gap={6}>
+      <TwoPanelWithScroll leftWidth="2fr" rightWidth="1fr" px={6} gap={6}>
         {/* Left Column - Visualization (Full Height) */}
-        <TwoPanelWithScroll.LeftPanel h="75vh">
+        <TwoPanelWithScroll.LeftPanel h="72vh">
           {uatData && (
             <PackedRadialTree
               data={uatData}
@@ -189,20 +191,13 @@ export function PackedRadialTreeDemo() {
             />
           )}
         </TwoPanelWithScroll.LeftPanel>
-
         {/* Right Column - Content */}
-        <TwoPanelWithScroll.RightPanel
-          maxW="72ch"
-          mx="auto"
-          pr={10}
-          maxH="calc(100vh - 120px)"
-          overflow="auto"
-        >
-          <Stack gap={6}>
+        <TwoPanelWithScroll.RightPanel>
+          <Stack gap={6} maxW="72ch">
             {/* Header */}
             <Box>
-              <Heading as="h1" size="2xl" color="accent">
-                Packed Radial Tree
+              <Heading as="h1" size="2xl" color="accent" mb={2}>
+                Explore Astronomy Concepts with a Packed Radial Tree
               </Heading>
               <Text fontSize="sm" color="gray.focusRing" mb={4}>
                 Custom-designed visualization by Karthik Badam, May 26, 2025.
@@ -219,7 +214,7 @@ export function PackedRadialTreeDemo() {
             {/* Selected Node Details */}
             {selectedNode ? (
               <Box>
-                <Heading as="h2" size="md" mb={1}>
+                <Heading as="h2" size="md" mb={1} color="accentSubtle">
                   Selected Concept
                 </Heading>
                 <VStack gap={4} align="stretch">
@@ -285,11 +280,7 @@ export function PackedRadialTreeDemo() {
                           mb={2}
                           color="gray.focusRing"
                         >
-                          DESCENDANT CONCEPTS ({descendants.length}
-                          {getDescendants(selectedNode).length > 20
-                            ? `/${getDescendants(selectedNode).length}`
-                            : ""}
-                          )
+                          DESCENDANT CONCEPTS ({descendants.length})
                         </Text>
                         <Wrap>
                           {descendants.map((desc) => (
@@ -319,7 +310,7 @@ export function PackedRadialTreeDemo() {
               </Box>
             ) : (
               <Box>
-                <Heading as="h2" size="md" mb={1}>
+                <Heading as="h2" size="md" mb={1} color="accentSubtle">
                   Top-level Concepts
                 </Heading>
                 <Wrap gap={2}>
@@ -344,28 +335,47 @@ export function PackedRadialTreeDemo() {
 
             {/* Interaction Guide */}
             <Box>
-              <Heading as="h2" size="md" mb={1}>
+              <Heading as="h2" size="md" mb={1} color="accentSubtle">
                 Interaction Guide
               </Heading>
-              <VStack gap={2} align="stretch">
-                <Text fontSize="sm">
-                  • <strong>Click</strong> any node to select and explore
-                </Text>
-                <Text fontSize="sm">
-                  • <strong>Hover</strong> for detailed tooltips
-                </Text>
-                <Text fontSize="sm">
-                  • <strong>Zoom</strong> with mouse wheel or trackpad
-                </Text>
-                <Text fontSize="sm">
-                  • <strong>Pan</strong> by dragging the background
-                </Text>
-              </VStack>
+              <List.Root fontSize="sm" ml={4} gap={1}>
+                <List.Item>
+                  <Text as="span" fontWeight="semibold">
+                    Click
+                  </Text>{" "}
+                  any node to select. Click again to unselect.
+                </List.Item>
+                <List.Item>
+                  <Text as="span" fontWeight="semibold">
+                    Double-Click
+                  </Text>{" "}
+                  any node to zoom into the sub-hierarchy. Use the navigation
+                  buttons on top left to return to root.
+                </List.Item>
+                <List.Item>
+                  <Text as="span" fontWeight="semibold">
+                    Hover
+                  </Text>{" "}
+                  for detailed tooltips.
+                </List.Item>
+                <List.Item>
+                  <Text as="span" fontWeight="semibold">
+                    Zoom
+                  </Text>{" "}
+                  with mouse wheel or trackpad.
+                </List.Item>
+                <List.Item>
+                  <Text as="span" fontWeight="semibold">
+                    Pan
+                  </Text>{" "}
+                  by dragging the background.
+                </List.Item>
+              </List.Root>
             </Box>
 
             {/* Dataset Description */}
             <Box>
-              <Heading as="h2" size="md" mb={2}>
+              <Heading as="h2" size="md" mb={2} color="accentSubtle">
                 About the Dataset
               </Heading>
               <Text fontSize="sm" color="gray.fg">
@@ -379,10 +389,10 @@ export function PackedRadialTreeDemo() {
 
             {/* Visualization Explanation */}
             <Box>
-              <Heading as="h3" size="md" mb={2}>
+              <Heading as="h3" size="md" mb={2} color="accentSubtle">
                 How It Works
               </Heading>
-              <VStack gap={3} align="stretch">
+              <VStack gap={1} align="stretch">
                 <Text fontSize="sm" color="gray.fg">
                   <strong>Circle Size:</strong> Represents the number of
                   descendant concepts

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import {
 } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 import { Page } from "../components/Page";
+import { TwoPanelWithScroll } from "../components/TwoPanelWithScroll";
 import { useColorModeValue } from "../components/ui/color-mode";
 import featuredData from "../data/featured.json";
 import { accent } from "../theme";
@@ -48,20 +49,8 @@ export const Home = () => {
   return (
     <Page>
       <Container maxW="container.xl" px={8}>
-        <Grid
-          templateColumns={{ base: "1fr", md: "320px 1fr" }}
-          gap="100px"
-          minHeight={{ base: "auto", md: "calc(100vh - 100px)" }}
-          mx="auto"
-          w="fit-content"
-        >
-          <Stack
-            gap={6}
-            position={{ base: "static", md: "sticky" }}
-            top={{ base: "auto", md: "0" }}
-            height={{ base: "auto", md: "fit-content" }}
-            alignSelf={{ base: "stretch", md: "start" }}
-          >
+        <TwoPanelWithScroll leftWidth="320px" rightWidth="1fr" gap="100px">
+          <TwoPanelWithScroll.LeftPanel gap={6}>
             <Stack position="relative" mt={10}>
               <Image
                 src="/profile.jpg"
@@ -103,8 +92,8 @@ export const Home = () => {
                 feed into large language and vision models.
               </Text>
             </Stack>
-          </Stack>
-          <Stack py={2}>
+          </TwoPanelWithScroll.LeftPanel>
+          <TwoPanelWithScroll.RightPanel py={2}>
             <Stack gap={4} maxW={{ base: "100%", lg: "80ch" }}>
               <Heading color="accent">Featured Works</Heading>
               {/* Featured Posts as Large Cards - Side by Side */}
@@ -154,8 +143,8 @@ export const Home = () => {
                 </Grid>
               )}
             </Stack>
-          </Stack>
-        </Grid>
+          </TwoPanelWithScroll.RightPanel>
+        </TwoPanelWithScroll>
       </Container>
     </Page>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -51,7 +51,7 @@ export const Home = () => {
       <Container maxW="container.xl" px={8}>
         <TwoPanelWithScroll leftWidth="320px" rightWidth="1fr" gap="100px">
           <TwoPanelWithScroll.LeftPanel gap={6}>
-            <Stack position="relative" mt={10}>
+            <Stack position="relative" mt={10} mb={6}>
               <Image
                 src="/profile.jpg"
                 alt="Karthik Badam"
@@ -207,7 +207,7 @@ const FeaturedCard = ({ post, image }: FeaturedCardProps) => (
       height="200px"
     />
     <Stack gap={2} flex="1">
-      <Heading size="md" fontWeight="semibold" color="accent">
+      <Heading size="sm" fontWeight="medium">
         {post.title}
       </Heading>
       <Text fontSize="sm" lineClamp={3} color="gray.focusRing">
@@ -249,7 +249,7 @@ const PostCard = ({ post }: PostCardProps) => (
     h="100%"
   >
     <Stack gap={2}>
-      <Heading size="md" fontWeight="semibold" color="accent">
+      <Heading size="sm" fontWeight="medium">
         {post.title}
       </Heading>
       <Text color="gray.focusRing" fontSize="sm" lineClamp={2}>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,7 +7,7 @@ export const accent = {
 };
 
 export const accentSubtle = {
-  light: "#a1a1aa",
+  light: "#0c5c72",
   dark: "#E8E0D0",
 };
 


### PR DESCRIPTION
## Summary
- implement `TwoPanelWithScroll` component for sticky two-panel layout
- refactor `Home.tsx` and `PRT.tsx` to use the new component
- keep left panel sticky on larger screens while allowing custom column widths

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854a6dc69f88321a9dde89fad73f505