### PR TITLE
fix: let demo buttons stay clickable while sessions API is loading

### DIFF
--- a/src/pages/Demos/LatentInsights/components/LandingScreen.tsx
+++ b/src/pages/Demos/LatentInsights/components/LandingScreen.tsx
@@ -72,7 +72,7 @@ export function LandingScreen() {
     loading: localLoading,
     refresh,
   } = useLocalSessions();
-  const isLoading = state.status === "loading" || localLoading;
+  const sessionLoading = state.status === "loading";
 
   // Config state for new session
   const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -86,20 +86,20 @@ export function LandingScreen() {
 
   const openLive = useCallback(
     (id: string) => {
-      if (isLoading) return;
+      if (sessionLoading) return;
       navigate(`/latent-insights/${id}`, { replace: true });
       loadLiveSession(id);
     },
-    [isLoading, navigate, loadLiveSession],
+    [sessionLoading, navigate, loadLiveSession],
   );
 
   const openSaved = useCallback(
     (id: string) => {
-      if (isLoading) return;
+      if (sessionLoading) return;
       navigate(`/latent-insights/${id}`, { replace: true });
       loadSavedSession(id);
     },
-    [isLoading, navigate, loadSavedSession],
+    [sessionLoading, navigate, loadSavedSession],
   );
 
   const handleFileSelect = useCallback(
@@ -241,11 +241,18 @@ export function LandingScreen() {
           </Flex>
 
           {/* Live sessions */}
-          {localSessions.length > 0 && (
+          {(localSessions.length > 0 || localLoading) && (
             <VStack gap={2} w="100%" alignItems="flex-start">
-              <Text fontSize="xs" color="fg.muted" fontFamily="mono">
-                Live sessions
-              </Text>
+              <Flex gap={2} align="center">
+                <Text fontSize="xs" color="fg.muted" fontFamily="mono">
+                  Live sessions
+                </Text>
+                {localLoading && (
+                  <Text fontSize="2xs" color="fg.muted" fontFamily="mono">
+                    loading…
+                  </Text>
+                )}
+              </Flex>
               {localSessions.map((s) => (
                 <Box
                   key={s.id}
@@ -256,11 +263,11 @@ export function LandingScreen() {
                   borderColor="gray.600"
                   borderRadius="md"
                   textAlign="left"
-                  cursor={isLoading ? "wait" : "pointer"}
+                  cursor={sessionLoading ? "wait" : "pointer"}
                   _hover={{ borderColor: "fg.muted" }}
                   transition="border-color 0.15s"
                   onClick={() => openLive(s.id)}
-                  opacity={isLoading ? 0.5 : 1}
+                  opacity={sessionLoading ? 0.5 : 1}
                 >
                   <Text fontSize="xs" fontFamily="mono" fontWeight="bold">
                     {s.dataset_path?.split("/").pop() ?? s.id.slice(0, SESSION_ID_PREVIEW_LENGTH)}
@@ -292,11 +299,11 @@ export function LandingScreen() {
                 borderColor="gray.600"
                 borderRadius="md"
                 textAlign="left"
-                cursor={isLoading ? "wait" : "pointer"}
+                cursor={sessionLoading ? "wait" : "pointer"}
                 _hover={{ borderColor: "fg.muted" }}
                 transition="border-color 0.15s"
                 onClick={() => openSaved(s.id)}
-                opacity={isLoading ? 0.5 : 1}
+                opacity={sessionLoading ? 0.5 : 1}
               >
                 <Text fontSize="xs" fontFamily="mono" fontWeight="bold">
                   {s.dataset}

--- a/src/pages/Demos/LatentInsights/components/LandingScreen.tsx
+++ b/src/pages/Demos/LatentInsights/components/LandingScreen.tsx
@@ -70,9 +70,11 @@ export function LandingScreen() {
   const {
     sessions: localSessions,
     loading: localLoading,
+    ready: sessionsReady,
     refresh,
   } = useLocalSessions();
   const sessionLoading = state.status === "loading";
+  const uploadDisabled = !sessionsReady;
 
   // Config state for new session
   const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -206,19 +208,27 @@ export function LandingScreen() {
               border="1px solid"
               borderColor={pendingFile ? "fg.muted" : "gray.600"}
               borderRadius="md"
-              cursor="pointer"
+              cursor={uploadDisabled ? "wait" : "pointer"}
               fontSize="xs"
               fontFamily="mono"
               color={pendingFile ? "fg" : "fg.muted"}
-              _hover={{ borderColor: "fg.muted" }}
+              _hover={uploadDisabled ? undefined : { borderColor: "fg.muted" }}
               transition="border-color 0.15s"
+              opacity={uploadDisabled ? 0.5 : 1}
+              pointerEvents={uploadDisabled ? "none" : undefined}
+              aria-disabled={uploadDisabled}
             >
-              {pendingFile ? pendingFile.name : "Select CSV"}
+              {uploadDisabled
+                ? "Connecting…"
+                : pendingFile
+                  ? pendingFile.name
+                  : "Select CSV"}
               <input
                 ref={fileInputRef}
                 type="file"
                 accept=".csv"
                 onChange={handleFileSelect}
+                disabled={uploadDisabled}
                 style={{ display: "none" }}
               />
             </Box>

--- a/src/pages/Demos/LatentInsights/hooks/useLocalSessions.ts
+++ b/src/pages/Demos/LatentInsights/hooks/useLocalSessions.ts
@@ -23,6 +23,7 @@ function deriveSessionStatus(
 export function useLocalSessions() {
   const [sessions, setSessions] = useState<LocalSession[]>([]);
   const [loading, setLoading] = useState(false);
+  const [ready, setReady] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -49,6 +50,7 @@ export function useLocalSessions() {
       // server not reachable
     } finally {
       setLoading(false);
+      setReady(true);
     }
   }, []);
 
@@ -56,5 +58,5 @@ export function useLocalSessions() {
     refresh();
   }, [refresh]);
 
-  return { sessions, loading, refresh };
+  return { sessions, loading, ready, refresh };
 }


### PR DESCRIPTION
Demo buttons (saved JSON files) had no dependency on the live sessions
API but were gated by a combined isLoading flag. Split into sessionLoading
(for active session loads) and localLoading (now only a small "loading…"
indicator next to the Live sessions header).